### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rosolko/allure-gradle-configuration/security/code-scanning/5](https://github.com/rosolko/allure-gradle-configuration/security/code-scanning/5)

To fix the problem, we should add an explicit `permissions:` block at the root of the workflow YAML file `.github/workflows/gradle.yml`, just after the `name:` and before the `on:` block. As per CodeQL and GitHub security recommendations, set `contents: read` as a safe, minimal starting point, since the workflow only checks out code, sets up Java, caches dependencies, builds/tests, and uploads an artifact. None of the steps appear to require write access to repository contents, issues, or pull requests, so no additional permissions are needed. No modifications to any of the jobs or steps are required; only the root-level addition of the block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
