### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 jobs:
   validation:
     name: Validate gradle wrapper
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/rosolko/allure-gradle-configuration/security/code-scanning/4](https://github.com/rosolko/allure-gradle-configuration/security/code-scanning/4)

To implement the fix, add a `permissions` block specifying `contents: read` at either the workflow or job level. Here, the minimal edit is to add it at the job level under the affected job (`validation`), directly after the job name. This restricts the GITHUB_TOKEN to read-only access to repository contents for this job, preventing accidental privilege escalation or misuse. No imports, definitions, or additional methods are needed; just a YAML block edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
