### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,7 @@
 name: automerge
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request_target:


### PR DESCRIPTION
Potential fix for [https://github.com/rosolko/allure-gradle-configuration/security/code-scanning/3](https://github.com/rosolko/allure-gradle-configuration/security/code-scanning/3)

Generally, to fix this problem, you should declare a `permissions` block at the workflow or job level, specifying only the minimum necessary permissions for the actions being performed. In this case, because the workflow automerges pull requests, it will need `pull-requests: write` and probably only `contents: read` at minimum. You should add a `permissions` block either at the root of the workflow YAML (applies to all jobs), or at the top of the `automerge` job (applies only to that job). Adding to the root is the preferred and most concise solution when all jobs share the same permissions. No changes to steps or actions are needed; just add the following to the workflow after the `name:` but before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
